### PR TITLE
added a few small things/fixed typo

### DIFF
--- a/docs/ml.rst
+++ b/docs/ml.rst
@@ -16,7 +16,13 @@ Machine Learning
 Machine Learning Interface models
 ------------------------------
 
-   These functions allows interfaces of various models into Gekko.
+   These functions allows interfaces of various models into Gekko. They can be found in the ML subpackage of gekko, imported like so:
+   
+   .. container:: cell code
+
+   .. code:: python
+
+      from gekko import ML
 
 .. py:class:: Model = ML.Gekko_GPR(model,Gekko_Model,modelType = 'sklearn',fixedKernel=True)
 
@@ -238,9 +244,9 @@ this function.
    .. code:: python
 
       #Import the ML interface functions
-      from Gekko.ML import Gekko_GPR,Gekko_SVR,Gekko_NN_SKlearn
-      from Gekko.ML import Gekko_NN_TF,Gekko_LinearRegression
-      from Gekko.ML import Bootstrap,Conformist,CustomMinMaxGekkoScaler
+      from gekko.ML import Gekko_GPR,Gekko_SVR,Gekko_NN_SKlearn
+      from gekko.ML import Gekko_NN_TF,Gekko_LinearRegression
+      from gekko.ML import Bootstrap,Conformist,CustomMinMaxGekkoScaler
       import pandas as pd
       from sklearn.model_selection import train_test_split
 


### PR DESCRIPTION
in the docs page, it has import Gekko.ML, which is incorrect; it should be import gekko.ML