### PR TITLE
Under WSL run win32 apm.exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The [most recent version is listed on PyPi](https://pypi.org/project/gekko/). Yo
 pip install --upgrade gekko
 ```
 
-GEKKO runs in remote mode (solved on high performance server) or on a local CPU when option ```remote=False``` such as ```m=GEKKO(remote=False)```. The pip package includes the Windows executable (apm.exe), a Linux executable (apm), a MacOS executable (apm_mac), and a Linux ARM processor executable such as for a Raspberry Pi (apm_arm). Gekko can be used with remote server access (default option) for all operating systems.
+GEKKO runs in remote mode (solved on high performance server) or on a local CPU when option ```remote=False``` such as ```m=GEKKO(remote=False)```. The pip package includes the Windows executable (apm.exe), a Linux executable (apm), a MacOS executable (apm_mac), and a Linux ARM processor executable such as for a Raspberry Pi (apm_arm). With Linux under WSL on x86 platform, the Windows executable is used. Gekko can be used with remote server access (default option) for all operating systems.
 
 ## What does GEKKO do?
 

--- a/gekko/gekko.py
+++ b/gekko/gekko.py
@@ -2117,6 +2117,8 @@ class GEKKO(object):
                     apm_exe = os.path.join(dirname,'bin','apm_aarch64')
                 elif (os.uname()[4].startswith("arm") or os.uname()[4].startswith("aarch")): # ARM / AARCH processor 32-bit
                     apm_exe = os.path.join(dirname,'bin','apm_arm')
+                elif "Microsoft" in os.uname().release or "WSL" in os.uname().release:
+                    apm_exe = os.path.join(dirname,'bin','apm.exe') # WSL is able to run win32 binaries
                 else: # Other Linux
                     apm_exe = os.path.join(dirname,'bin','apm')
             else:


### PR DESCRIPTION
When running Linux under WSL on a Windows host, select apm.exe for local execution. WSL is able to execute win32 binaries, and so able to use those features (e.g. IPOPT) that are excluded from the Linux version of the apm binary.

I do not have access to an arm machine to verify that WSL for arm is also able to run win32 binaries or that its emulated performance is acceptable; therefore, the choice to order WSL check after the arm machine check is conservatively deliberate.

The chosen method of WSL detection follows the instructions from Microsoft in a manner similar to how it's done by systemd-detect-virt:

 - https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
 - https://github.com/systemd/systemd/blob/a7e508f/src/basic/virt.c#L473

I'm deliberately keeping the change local and minimal to reduce review burden and risk.